### PR TITLE
fix(api): set id for update

### DIFF
--- a/pipeline/respository.go
+++ b/pipeline/respository.go
@@ -74,6 +74,7 @@ func (r *InMemoryRepository) Update(id ID, pipeline *Pipeline) (*Pipeline, error
 		return nil, err
 	}
 
+	pipeline.ID = id
 	r.pipelines[i] = pipeline
 
 	return pipeline, nil

--- a/test/features/step_definitions/api/pipeline/update_steps.rb
+++ b/test/features/step_definitions/api/pipeline/update_steps.rb
@@ -42,5 +42,8 @@ Then('we should have an updated simple pipeline') do
   expect(@response.code).to eq(200)
 
   res = JSON.parse(@response.body)
-  expect(res['pipeline']['name']).to eq('update-test')
+  pipeline = res['pipeline']
+
+  expect(pipeline['name']).to eq('update-test')
+  expect(pipeline['id']).to eq(@id)
 end


### PR DESCRIPTION
We forgot to make sure the pipeline id was set when updating
